### PR TITLE
Updated to match errors lesson

### DIFF
--- a/app/routes/cat_routes.py
+++ b/app/routes/cat_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, abort, make_response
 
 cat_bp = Blueprint("cat", __name__,url_prefix="/cats")
 
@@ -27,10 +27,10 @@ def handle_cat(cat_id):
     try:
         cat_id = int(cat_id)
     except:
-        return "Bad data", 400
+        return abort(make_response({"message": f"Cat {cat_id} invalid"}, 400))
 
     for cat in cats:
         if cat.id == cat_id:
             return vars(cat)
             
-    return "Not found", 404
+    return abort(make_response({"message": f" Cat {cat_id} Not found"}, 404))

--- a/app/routes/dog_routes.py
+++ b/app/routes/dog_routes.py
@@ -8,7 +8,7 @@ class Dog:
         self.name = name
         self.breed = breed
         if not tricks:
-            tricks = []
+            self.tricks = []
         self.tricks = tricks
 
     def to_json(self):

--- a/app/routes/dog_routes.py
+++ b/app/routes/dog_routes.py
@@ -7,21 +7,14 @@ class Dog:
         self.id = id
         self.name = name
         self.breed = breed
-        if not tricks:
-            self.tricks = []
-        self.tricks = tricks
+        self.tricks = tricks or []
 
     def to_json(self):
-        if not self.tricks:
-            tricks = []
-        else:
-            tricks = self.tricks
-
         return {
                 "id": self.id,
                 "name": self.name,
                 "breed": self.breed,
-                "tricks": tricks
+                "tricks": self.tricks
             }
 
 dogs = [

--- a/app/routes/dog_routes.py
+++ b/app/routes/dog_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, abort, make_response
 
 dog_bp = Blueprint("dog", __name__,url_prefix="/dogs")
 
@@ -13,7 +13,7 @@ class Dog:
 
     def to_json(self):
         if not self.tricks:
-            tricks = "No Tricks"
+            tricks = []
         else:
             tricks = self.tricks
 
@@ -62,4 +62,4 @@ def handle_dog(dog_id):
             # }
             return dog.to_json()
 
-    return {"error": "Dog not found"}, 404
+    return abort(make_response({"message": f"Dog {dog_id} Not found"}, 404))


### PR DESCRIPTION
- Uses `abort` and `make_response` for 401, and 404
- Changed `self.tricks` to return empty list instead of a string to avoid mixing of data types. 